### PR TITLE
Fix missing closing paragraph tags in index

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,8 +56,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
           <strong>12&nbsp;% des jeunes sont considérés à risque de développer une pratique problématique</strong> (gaming disorder) selon l'OMS.
         </li>
       </ul>
-       <p style="margin-top: 1.5em;">Notre mission est de transformer ce temps d'écran en une expérience constructive.</p>
-      <p style="text-align:center; margin-top:2em;"><a href="enjeux.html" class="btn">Voir les chiffres &amp; sources détaillés</a>
+      <p style="margin-top: 1.5em;">Notre mission est de transformer ce temps d'écran en une expérience constructive.</p>
+      <p style="text-align:center; margin-top:2em;"><a href="enjeux.html" class="btn">Voir les chiffres &amp; sources détaillés</a></p>
     </section>
 
 
@@ -74,7 +74,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
           <img src="assets/images/logo_besf.png" alt="Logo de la Fédération Belge d'Esport" style="max-height: 70px; object-fit: contain;">
         </a>
       </div>
-      <p style="text-align:center; margin-top:2em;"><a href="academie.html" class="btn">Découvrir notre académie</a>
+      <p style="text-align:center; margin-top:2em;"><a href="academie.html" class="btn">Découvrir notre académie</a></p>
     </section>
 
       <section class="section card" style="text-align:center;">


### PR DESCRIPTION
## Summary
- close unclosed paragraph tags on the home page for valid HTML markup

## Testing
- `npx htmlhint index.html` *(fails: 403 Forbidden)*
- `python -m html.parser index.html`


------
https://chatgpt.com/codex/tasks/task_e_68949204f5a08330867a42367c1b0163